### PR TITLE
Enable annotation mapping for Validator.

### DIFF
--- a/src/Hostnet/FormTwigBridge/Builder.php
+++ b/src/Hostnet/FormTwigBridge/Builder.php
@@ -48,10 +48,12 @@ class Builder
    * @todo allow to add own form extensions?
    * @return \Symfony\Component\Form\FormFactoryInterface
    */
-  public function buildFormFactory()
+  public function buildFormFactory($enableAnnotationMapping = false)
   {
     $this->ensureCsrfProviderExists();
-    $validator = Validation::createValidator();
+    $validator = $enableAnnotationMapping ?
+      Validation::createValidatorBuilder()->enableAnnotationMapping()->getValidator() :
+      Validation::createValidator();
     return Forms::createFormFactoryBuilder()->addExtension(new CsrfExtension($this->csrf_provider))
                                             ->addExtension(new ValidatorExtension($validator))
                                             ->addExtension(new HttpFoundationExtension())


### PR DESCRIPTION
Yo,

Here's another small PR for you. This one allows users to enable annotation mapping on the Symfony `Validator` instance the `Builder` from this library constructs.

This enables the Validator annotations to be applied to a target entity. As far as I can tell, this PR is fairly safe, as it defaults to existing behavior. Of course, if you enable them and don't have Doctrine installed, it will scream fairly loudly.

-Sam
