### PR TITLE
Add support to register custom form extensions.

### DIFF
--- a/src/Hostnet/FormTwigBridge/Builder.php
+++ b/src/Hostnet/FormTwigBridge/Builder.php
@@ -12,6 +12,8 @@ use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
 
 use Symfony\Component\Form\Forms;
 
+use Symfony\Component\Form\FormFactoryBuilder;
+
 /**
  * Uses the builder pattern to create a form factory and a Twig_Environment through the
  * TwigEnvironmentBuilder
@@ -45,17 +47,25 @@ class Builder
 
   /**
    * Builds the factory
-   * @todo allow to add own form extensions?
    * @return \Symfony\Component\Form\FormFactoryInterface
    */
   public function buildFormFactory()
   {
     $this->ensureCsrfProviderExists();
     $validator = Validation::createValidator();
-    return Forms::createFormFactoryBuilder()->addExtension(new CsrfExtension($this->csrf_provider))
-                                            ->addExtension(new ValidatorExtension($validator))
-                                            ->addExtension(new HttpFoundationExtension())
-                                            ->getFormFactory();
+    $builder = Forms::createFormFactoryBuilder()->addExtension(new CsrfExtension($this->csrf_provider))
+                                                ->addExtension(new ValidatorExtension($validator))
+                                                ->addExtension(new HttpFoundationExtension());
+    $this->registerFormExtensions($builder);
+    return $builder->getFormFactory();
+  }
+
+  /**
+   * Users should subclass this Builder and override this method to register
+   * any extra Form Extensions they require.
+   * @param FormFactoryBuilder $builder
+   */
+  protected function registerFormExtensions(FormFactoryBuilder $builder) {
   }
 
   private function ensureCsrfProviderExists()


### PR DESCRIPTION
You had a @todo in the `Builder` - turned out it was something I needed.

Not sure if you like this particular approach, I don't really care how it's implemented so long as I can provide a bunch of custom form extension objects.

-Sam
