### PR TITLE
Fixed dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "source": "https://github.com/hostnet/form-twig-bridge"
     },
     "require": {
-        "symfony/form": ">=2.3,<2.6",
-        "symfony/validator": ">=2.3,<2.6",
-        "symfony/config": ">=2.3,<2.6",
-        "symfony/translation": ">=2.3,<2.6",
-        "symfony/twig-bridge": ">=2.3,<2.6",
-        "symfony/http-foundation": ">=2.3,<2.6"
+        "symfony/form"           : "2.*, >=2.3",
+        "symfony/validator"      : "2.*, >=2.3",
+        "symfony/config"         : "2.*, >=2.3",
+        "symfony/translation"    : "2.*, >=2.3",
+        "symfony/twig-bridge"    : "2.*, >=2.3",
+        "symfony/http-foundation": "2.*, >=2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"


### PR DESCRIPTION
Removed the top dependencies. They require too much maintenance. If a certain Symfony version is broken, a PR or Issue should be made to fix it.  Right now installing even prevents testing it in newer version. 